### PR TITLE
remove obsolete `updateAbsoluteURL` methods from sitetree and file links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "silverstripe/cms": "~5.0",
         "fromholdio/silverstripe-dependentgroupeddropdownfield": "^3.0.0",
         "fromholdio/silverstripe-externalurlfield": "^1.1.0",
-        "innoweb/silverstripe-international-phone-number-field": "^5.0.0"
+        "innoweb/silverstripe-international-phone-number-field": "^5.0.0",
+        "unclecheese/display-logic": "^3.0.0"
     },
     "suggest": {
         "fromholdio/silverstripe-dbhtmlanchors":  "",

--- a/src/Extensions/FileLink.php
+++ b/src/Extensions/FileLink.php
@@ -60,12 +60,6 @@ class FileLink extends SuperLinkTypeExtension
         $url = $this->getOwner()->getLinkedFile()?->Link();
     }
 
-    public function updateAbsoluteURL(?string &$url): void
-    {
-        if (!$this->isLinkTypeMatch()) return;
-        $url = $this->getOwner()->getLinkedFile()?->AbsoluteLink();
-    }
-
     public function isDownloadForced(): bool
     {
         if (!$this->isLinkTypeMatch()) return false;

--- a/src/Extensions/SiteTreeLink.php
+++ b/src/Extensions/SiteTreeLink.php
@@ -102,12 +102,6 @@ class SiteTreeLink extends SuperLinkTypeExtension
         if (!empty($anchor)) $url .= '#' . $anchor;
     }
 
-    public function updateAbsoluteURL(?string &$url): void
-    {
-        if (!$this->isLinkTypeMatch()) return;
-        $url = $this->getOwner()->getLinkedSiteTree()?->AbsoluteLink();
-    }
-
     public function getAllowedLinkedSiteTreeRoot(): ?SiteTree
     {
         $siteTree = null;


### PR DESCRIPTION
removes duplicated code and allows subclasses to manipulate the link in one place instead of having to override both `updateURL` and `updateAbsoluteURL`.